### PR TITLE
Fix resize.f2fs exit code

### DIFF
--- a/fsck/main.c
+++ b/fsck/main.c
@@ -618,7 +618,8 @@ fsck_again:
 			goto out_err;
 		break;
 	case RESIZE:
-		if (do_resize(sbi))
+                ret = do_resize(sbi);
+		if (ret)
 			goto out_err;
 		break;
 	case SLOAD:


### PR DESCRIPTION
Exit with non-zero exit code if resize.f2fs fails